### PR TITLE
Added support for dark mode icon

### DIFF
--- a/Statusfy/SFYAppDelegate.m
+++ b/Statusfy/SFYAppDelegate.m
@@ -60,7 +60,9 @@ static NSString * const SFYPlayerStatePreferenceKey = @"ShowPlayerState";
         self.statusItem.title = titleText;
     }
     else {
-        self.statusItem.image = [NSImage imageNamed:@"status_icon"];
+        NSImage *image = [NSImage imageNamed:@"status_icon"];
+        [image setTemplate:true];
+        self.statusItem.image = image;
         self.statusItem.title = nil;
     }
 }


### PR DESCRIPTION
The icon in the menu bar is now visible when the OS X dark mode is used.