### PR TITLE
Use grey font for artist & shrink font size

### DIFF
--- a/Statusfy/SFYAppDelegate.m
+++ b/Statusfy/SFYAppDelegate.m
@@ -57,15 +57,28 @@ static NSString * const SFYPlayerDockIconPreferenceKey = @"YES";
     NSString *artistName = [[self executeAppleScript:@"get artist of current track"] stringValue];
     
     if (trackName && artistName) {
-        NSString *titleText = [NSString stringWithFormat:@"%@ - %@", trackName, artistName];
-        
+        NSString *titleText = [NSString stringWithFormat:@"%@ %@", trackName, artistName];
+      
+      NSRange range = [titleText rangeOfString:artistName];
+      NSColor *color = [NSColor colorWithWhite:0.5 alpha:1.0];
+      NSDictionary *defaultAttributes = [NSDictionary
+                                  dictionaryWithObjectsAndKeys:
+                                  [NSColor colorWithWhite:1.0 alpha:1.0],NSForegroundColorAttributeName,
+                                  [NSFont menuBarFontOfSize:12], NSFontAttributeName,
+                                  nil];
+      
+      NSMutableAttributedString *attString = [[NSMutableAttributedString alloc] initWithString:titleText attributes:defaultAttributes];
+
+      [attString addAttribute:NSForegroundColorAttributeName value:color range:range];
+      
         if ([self getPlayerStateVisibility]) {
-            NSString *playerState = [self determinePlayerStateText];
-            titleText = [NSString stringWithFormat:@"%@ (%@)", titleText, playerState];
+          NSString *formattedString = [NSString stringWithFormat:@" (%@)", [self determinePlayerStateText]];
+            NSAttributedString *playerState = [[NSAttributedString alloc] initWithString:formattedString attributes:defaultAttributes];
+          [attString appendAttributedString:playerState];
         }
         
         self.statusItem.image = nil;
-        self.statusItem.title = titleText;
+        [self.statusItem setAttributedTitle:attString];
     }
     else {
         NSImage *image = [NSImage imageNamed:@"status_icon"];

--- a/Statusfy/SFYAppDelegate.m
+++ b/Statusfy/SFYAppDelegate.m
@@ -26,7 +26,10 @@ static NSString * const SFYPlayerDockIconPreferenceKey = @"YES";
 {
     //Initialize the variable the getDockIconVisibility method checks
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:SFYPlayerDockIconPreferenceKey];
-    
+  
+    // Default to hidden dock icon
+    [NSApp setActivationPolicy: NSApplicationActivationPolicyAccessory];
+  
     self.statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
     self.statusItem.highlightMode = YES;
     


### PR DESCRIPTION
The simplicity of this app is great. However, I really wanted to have a grey "disabled color" for the artist  text. I've also shrunk the font size to 12 (default is 14). 

Feel free to merge if you're interested in the changes.

Original:
<img width="281" alt="screen shot 2016-12-03 at 9 07 07 pm" src="https://cloud.githubusercontent.com/assets/930621/20863559/88429048-b99c-11e6-80d0-069f02bfce42.png">


Updated:
<img width="266" alt="screen shot 2016-12-03 at 9 05 54 pm" src="https://cloud.githubusercontent.com/assets/930621/20863555/4e673644-b99c-11e6-9670-9031f407ab69.png">

