### PR TITLE
Hide dock icon by default

### DIFF
--- a/Statusfy/SFYAppDelegate.m
+++ b/Statusfy/SFYAppDelegate.m
@@ -44,6 +44,8 @@ static NSString * const SFYPlayerDockIconPreferenceKey = @"YES";
     
     [self setStatusItemTitle];
     [NSTimer scheduledTimerWithTimeInterval:1 target:self selector:@selector(setStatusItemTitle) userInfo:nil repeats:YES];
+
+    [self toggleDockIconVisibility];
 }
 
 #pragma mark - Setting title text


### PR DESCRIPTION
As seen in https://github.com/paulyoung/Statusfy/issues/21#issuecomment-360355115

Ideally, the app should store in the preferences what was the last state. As a quick solution until then, this PR hides the dock icon by default.